### PR TITLE
Replace Career Center page with "jobs"

### DIFF
--- a/lms/static/sass/_catalog.scss
+++ b/lms/static/sass/_catalog.scss
@@ -124,6 +124,11 @@
 
 	.course-item
 	{
+    figure {
+      img {
+        width:100%;
+      }
+    }
 		figcaption
 		{
 			background: #444;

--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -310,6 +310,7 @@ $register-banner-image: none;
 @import 'register';
 @import 'tertiary_navigation';
 @import 'system_status';
+@import 'urls';
 
 @import 'prism'; //used for prism.js syntax highlighting
 
@@ -361,6 +362,15 @@ body.register,
 .container
 {
 	min-width:0px !important;
+}
+
+body,
+body.view-in-course
+{
+  div.window-wrap
+  {
+    min-width:inherit;
+  }
 }
 
 #primary-nav, #secondary-nav, .wrapper-footer

--- a/lms/static/sass/_register.scss
+++ b/lms/static/sass/_register.scss
@@ -1,3 +1,16 @@
+.login-register,
+#login-and-registration-container
+{
+  background: transparent;
+}
+
+.login-register
+{
+  form {
+    background:white;
+  }
+}
+
 .register.container, .login.container
 {
   background-color:white;

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -116,7 +116,7 @@ ${HTML(fragment.foot_html())}
     <div class="course-wrapper">
 
       % if disable_accordion is UNDEFINED or not disable_accordion:
-          <div class="col-md-3 no-right-pad">
+          <div class="col-sm-3 no-right-pad">
             <div class="course-index">
               <div class="wrapper-course-modes">
 
@@ -141,7 +141,7 @@ ${HTML(fragment.foot_html())}
           </div>
       % endif
 
-      <section class="col-md-9 no-left-pad">
+      <section class="col-sm-9 no-left-pad">
         <div class="course-content" id="course-content">
           <main id="main" aria-label="Content" tabindex="-1">
             % if getattr(course, 'entrance_exam_enabled') and \

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -17,7 +17,7 @@
         <div class="col-md-4">
           <ol class="list-inline text-center footer-link-list">
             <li><a href="https://medium.com/gymnasium" target="_blank">Blog</a></li>
-            <li><a href="https://gymnasium.jobboard.io" target="_blank">Jobs</a></li>
+            <li><a href="${reverse('jobs')}">Jobs</a></li>
             <li><a href="${reverse('about')}">About</a></li>
             <li><a href="${marketing_link('FAQ')}">FAQ</a></li>
             <li><a href="${reverse('support')}">Support</a></li>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -17,6 +17,7 @@
         <div class="col-md-4">
           <ol class="list-inline text-center footer-link-list">
             <li><a href="https://medium.com/gymnasium" target="_blank">Blog</a></li>
+            <li><a href="https://gymnasium.jobboard.io" target="_blank">Jobs</a></li>
             <li><a href="${reverse('about')}">About</a></li>
             <li><a href="${marketing_link('FAQ')}">FAQ</a></li>
             <li><a href="${reverse('support')}">Support</a></li>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -99,7 +99,7 @@ site_status_msg = get_site_status_msg(course_id)
               <ul class="nav navbar-nav navbar-right">
 
                 <li><a href="/courses">Courses</a></li>
-                <li><a href="https://gymnasium.jobboard.io">Jobs</a></li>
+                <li><a href="/jobs">Jobs</a></li>
                 <li><a href="/about">About</a></li>
 
                 % if user.is_authenticated():

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -98,8 +98,9 @@ site_status_msg = get_site_status_msg(course_id)
             <div class="collapse navbar-collapse" id="secondary-nav-items">
               <ul class="nav navbar-nav navbar-right">
 
-                <li><a href="/courses">Catalog</a></li>
-                <li><a href="/careers">Career Center</a></li>
+                <li><a href="/courses">Courses</a></li>
+                <li><a href="https://gymnasium.jobboard.io">Jobs</a></li>
+                <li><a href="/about">About</a></li>
 
                 % if user.is_authenticated():
 

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -2,7 +2,7 @@
 <%inherit file="../main.html" />
 <% import urllib2 %>
 
-<%block name="pagetitle">${_("Privacy Policy")}</%block>
+<%block name="pagetitle">${_("Jobs")}</%block>
 <div class="container ">
 	<div class="row">
 		<div class="col-md-12 ">

--- a/lms/templates/student_account/access.underscore
+++ b/lms/templates/student_account/access.underscore
@@ -1,0 +1,23 @@
+<section id="login-anchor" class="form-type">
+    <div id="login-form" class="form-wrapper <% if ( mode !== 'login' ) { %>hidden<% } %>"></div>
+</section>
+
+<section id="register-anchor" class="form-type"> 
+  <div class="row">
+    <div class="col-md-12">
+      <div id="register-form" class="form-wrapper <% if ( mode !== 'register' ) { %>hidden<% } %>"></div>
+    </div>
+  </div>
+</section>
+
+<section id="password-reset-anchor" class="form-type">
+    <div id="password-reset-form" class="form-wrapper hidden"></div>
+</section>
+
+<section id="institution_login-anchor" class="form-type">
+    <div id="institution_login-form" class="form-wrapper hidden"></div>
+</section>
+
+<section id="hinted-login-anchor" class="form-type">
+    <div id="hinted-login-form" class="form-wrapper <% if ( mode !== 'hinted_login' ) { %>hidden<% } %>"></div>
+</section>

--- a/lms/templates/student_account/account.underscore
+++ b/lms/templates/student_account/account.underscore
@@ -1,0 +1,19 @@
+<form id="email-change-form" method="post">
+    <label for="new-email"><%- gettext("New Address") %></label>
+    <input id="new-email" type="text" name="new-email" value="" placeholder="xsy@edx.org" data-validate="required email"/>
+    <div id="new-email-status" />
+
+    <label for="password"><%- gettext("Password") %></label>
+    <input id="password" type="password" name="password" value="" data-validate="required"/>
+    <div id="password-status" />
+
+    <div class="submit-button">
+        <input type="submit" id="email-change-submit" value="<%- gettext("Change My Email Address") %>">
+    </div>
+    <div id="request-email-status" />
+
+    <div id="password-reset">
+        <a href="#"><%- gettext("Reset Password") %></a>
+    </div>
+    <div id="password-reset-status" />
+</form>

--- a/lms/templates/student_account/account_settings.underscore
+++ b/lms/templates/student_account/account_settings.underscore
@@ -1,0 +1,17 @@
+<main id="main" aria-label="Content" tabindex="-1">
+<div class="account-settings-container">
+    <div class="wrapper-header">
+        <h2 class="header-title"><%- gettext("Account Settings") %></h2>
+        <ul class="left list-inline account-nav">
+            <% _.each(accountSettingsTabs, function(tab) { %>
+            <li class="account-nav-item">
+                <button id="<%- tab.id %>" data-name="<%- tab.name %>" <% if (tab.class) { %> aria-describedby="header-subtitle-<%- tab.name %>" <% } %> class="account-nav-link <%- tab.class %>" ><%- tab.label %></button>
+            </li>
+            <% }); %>
+        </ul>
+    </div>
+
+    <div class="account-settings-sections">
+    </div>
+</div>
+</main>

--- a/lms/templates/student_account/account_settings_section.underscore
+++ b/lms/templates/student_account/account_settings_section.underscore
@@ -1,0 +1,18 @@
+<% _.each(sections, function(section) { %>
+    <div class="section">
+        <% if (section.subtitle) { %>
+            <p id="header-subtitle-<%- activeTabName %>" class="account-settings-header-subtitle"><%- section.subtitle %></p>
+        <% } %>
+        <h3 class="section-header"><%- gettext(section.title) %></h3>
+        <div class="account-settings-section-body">
+            <div class="ui-loading-indicator">
+                <span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span>
+                <span class="copy"><%- gettext("Loading") %></span>
+            </div>
+            <div class="ui-loading-error is-hidden">
+                <span class="fa fa-exclamation-triangle message-error" aria-hidden="true"></span>
+                <span class="copy"><%- gettext("An error occurred. Please reload the page.") %></span>
+            </div>
+        </div>
+    </div>
+<% }); %>

--- a/lms/templates/student_account/finish_auth.html
+++ b/lms/templates/student_account/finish_auth.html
@@ -1,0 +1,19 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%namespace name='static' file='/static_content.html'/>
+<%inherit file="/main.html" />
+
+<%block name="pagetitle">${_("Please Wait")}</%block>
+
+<%block name="headextra">
+<%static:require_module module_name="js/student_account/views/finish_auth_factory" class_name="FinishAuthFactory">
+    FinishAuthFactory();
+</%static:require_module>
+</%block>
+
+<div class="finish-auth">
+    <div class="finish-auth-inner">
+        <h1>${_('Please wait')}</h1>
+
+        <div class="loading-animation"></div>
+    </div>
+</div>

--- a/lms/templates/student_account/form_field.underscore
+++ b/lms/templates/student_account/form_field.underscore
@@ -1,0 +1,69 @@
+<div class="form-field <%=type%>-<%= name %>">
+    <% if ( type !== 'checkbox' ) { %>
+        <label for="<%= form %>-<%= name %>">
+            <%= label %>
+            <% if ( required && requiredStr ) { %> <%= requiredStr %></label><% } %>
+        </label>
+    <% } %>
+
+    <% if ( type === 'select' ) { %>
+        <select id="<%= form %>-<%= name %>"
+            name="<%= name %>"
+            class="input-inline"
+            aria-describedby="<%= form %>-<%= name %>-desc"
+            <% if ( typeof errorMessages !== 'undefined' ) {
+                _.each(errorMessages, function( msg, type ) {%>
+                    data-errormsg-<%= type %>="<%= msg %>"
+            <%  });
+            } %>
+            <% if ( required ) { %> aria-required="true" required<% } %>>
+        <% _.each(options, function(el) { %>
+            <option value="<%= el.value%>"<% if ( el.default ) { %> data-isdefault="true"<% } %>><%= el.name %></option>
+        <% }); %>
+        </select>
+        <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+    <% } else if ( type === 'textarea' ) { %>
+        <textarea id="<%= form %>-<%= name %>"
+            type="<%= type %>"
+            name="<%= name %>"
+            class="input-block"
+            aria-describedby="<%= form %>-<%= name %>-desc"
+            <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
+            <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
+            <% if ( typeof errorMessages !== 'undefined' ) {
+                _.each(errorMessages, function( msg, type ) {%>
+                    data-errormsg-<%= type %>="<%= msg %>"
+            <%  });
+            } %>
+            <% if ( required ) { %> aria-required="true" required<% } %> ></textarea>
+            <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+    <% } else { %>
+        <input id="<%= form %>-<%= name %>"
+           type="<%= type %>"
+           name="<%= name %>"
+           class="input-block <% if ( type === 'checkbox' ) { %>checkbox<% } %>"
+            <% if ( type !== 'password' ) { %> aria-describedby="<%= form %>-<%= name %>-desc" <% } %>
+            <% if ( restrictions.min_length ) { %> minlength="<%= restrictions.min_length %>"<% } %>
+            <% if ( restrictions.max_length ) { %> maxlength="<%= restrictions.max_length %>"<% } %>
+            <% if ( required ) { %> aria-required="true" required<% } %>
+            <% if ( typeof errorMessages !== 'undefined' ) {
+                _.each(errorMessages, function( msg, type ) {%>
+                    data-errormsg-<%= type %>="<%= msg %>"
+            <%  });
+            } %>
+            <% if ( placeholder ) { %> placeholder="<%= placeholder %>"<% } %>
+            value="<%- defaultValue %>"
+        />
+        <% if ( type === 'checkbox' ) { %>
+            <label for="<%= form %>-<%= name %>">
+                <%= label %>
+                <% if ( required && requiredStr ) { %> <%= requiredStr %><% } %>
+            </label>
+        <% } %>
+        <% if ( instructions ) { %> <span class="tip tip-input" id="<%= form %>-<%= name %>-desc"><%= instructions %></span><% } %>
+    <% } %>
+
+    <% if( form === 'login' && name === 'password' ) { %>
+        <a href="#" class="forgot-password field-link"><%- gettext("Forgot password?") %></a>
+    <% } %>
+</div>

--- a/lms/templates/student_account/hinted_login.underscore
+++ b/lms/templates/student_account/hinted_login.underscore
@@ -1,0 +1,28 @@
+<div class="wrapper-other-login">
+    <div class="section-title lines">
+        <h2>
+            <span class="text"><%- gettext("Sign in") %></span>
+        </h2>
+    </div>
+
+    <p class="instructions"><%- _.sprintf( gettext("Would you like to sign in using your %(providerName)s credentials?"), { providerName: hintedProvider.name } ) %></p>
+
+    <button class="action action-primary action-update proceed-button button-<%- hintedProvider.id %> hinted-login-<%- hintedProvider.id %>">
+        <span class="icon <% if ( hintedProvider.iconClass ) { %>fa <%- hintedProvider.iconClass %><% } %>" aria-hidden="true">
+            <% if ( hintedProvider.iconImage ) { %>
+                <img class="icon-image" src="<%- hintedProvider.iconImage %>" alt="<%- hintedProvider.name %> icon" />
+            <% } %>
+        </span>
+        <%- _.sprintf( gettext("Sign in using %(providerName)s"), { providerName: hintedProvider.name } ) %>
+    </button>
+
+    <div class="section-title lines">
+        <h2>
+            <span class="text"><%- gettext("or") %></span>
+        </h2>
+    </div>
+
+    <div class="toggle-form">
+        <button class="nav-btn form-toggle" data-type="login"><%- gettext("Show me other ways to sign in or register") %></button>
+    </div>
+</div>

--- a/lms/templates/student_account/institution_login.underscore
+++ b/lms/templates/student_account/institution_login.underscore
@@ -1,0 +1,31 @@
+<div class="wrapper-other-login">
+    <div class="section-title lines">
+        <h2>
+            <span class="text">
+                <%- gettext("Sign in with Institution/Campus Credentials") %>
+            </span>
+        </h2>
+    </div>
+
+    <p class="instructions"><%- gettext("Choose your institution from the list below:") %></p>
+
+    <ul class="institution-list">
+        <% _.each( _.sortBy(providers, "name"), function( provider ) {
+            if ( provider.loginUrl ) { %>
+                <li class="institution">
+                    <a class="institution-login-link" href="<%- provider.loginUrl %>"><%- provider.name %></a>
+                </li>
+            <% }
+        }); %>
+    </ul>
+
+    <div class="section-title lines">
+        <h2>
+            <span class="text"><%- gettext("or") %></span>
+        </h2>
+    </div>
+
+    <div class="toggle-form">
+        <button class="nav-btn form-toggle" data-type="login"><%- gettext("Back to sign in") %></button>
+    </div>
+</div>

--- a/lms/templates/student_account/institution_register.underscore
+++ b/lms/templates/student_account/institution_register.underscore
@@ -1,0 +1,31 @@
+<div class="wrapper-other-login">
+    <div class="section-title lines">
+        <h2>
+            <span class="text">
+                <%- gettext("Register with Institution/Campus Credentials") %>
+            </span>
+        </h2>
+    </div>
+
+    <p class="instructions"><%- gettext("Choose your institution from the list below:") %></p>
+
+    <ul class="institution-list">
+        <% _.each( _.sortBy(providers, "name"), function( provider ) {
+            if ( provider.registerUrl ) { %>
+                <li class="institution">
+                    <a class="institution-login-link" href="<%- provider.registerUrl %>"><%- provider.name %></a>
+                </li>
+            <% }
+        }); %>
+    </ul>
+
+    <div class="section-title lines">
+        <h2>
+            <span class="text"><%- gettext("or") %></span>
+        </h2>
+    </div>
+
+    <div class="toggle-form">
+        <button class="nav-btn form-toggle" data-type="register"><%- gettext("Register through edX") %></button>
+    </div>
+</div>

--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,0 +1,91 @@
+<div class="status already-authenticated-msg hidden">
+    <% if (context.currentProvider) { %>
+        <p class="message-copy">
+            <%- _.sprintf( gettext("You have successfully signed into %(currentProvider)s, but your %(currentProvider)s account does not have a linked %(platformName)s account. To link your accounts, sign in now using your %(platformName)s password."), context ) %>
+        </p>
+    <% } %>
+</div>
+
+<div aria-live="polite">
+    <div class="js-reset-success status submission-success hidden">
+        <h4 class="message-title"><%- gettext("Password Reset Email Sent") %></h4>
+        <div class="message-copy">
+            <p>
+                <%- gettext("We've sent instructions for resetting your password to the email address you provided.") %>
+            </p>
+        </div>
+    </div>
+
+    <div class="status submission-error hidden">
+        <h4 class="message-title"><%- gettext("We couldn't sign you in.") %></h4>
+        <ul class="message-copy"></ul>
+    </div>
+</div>
+
+<% if (context.errorMessage) { %>
+    <div class="status submission-error">
+        <h4 class="message-title"><%- _.sprintf( gettext("An error occurred when signing you in to %(platformName)s."), context ) %></h4>
+        <ul class="message-copy"><%- context.errorMessage %></ul>
+    </div>
+<% } %>
+
+<form id="login" class="login-form" tabindex="-1">
+
+    <div class="section-title lines">
+        <h2>
+            <span class="text">Sign In</span>
+        </h2>
+    </div>
+
+    <p class="sr">
+        <% if ( context.providers.length > 0 && !context.currentProvider || context.hasSecondaryProviders ) { %>
+            <%- gettext("Sign in here using your email address and password, or use one of the providers listed below.") %>
+        <% } else { %>
+            <%- gettext("Sign in here using your email address and password.") %>
+        <% } %>
+        <%- gettext("If you do not yet have an account, use the button below to register.") %>
+    </p>
+
+    <%= context.fields %>
+
+    <button type="submit" class="gym-button js-login login-button"><%- gettext("Sign in") %></button>
+
+    <% if ( context.providers.length > 0 && !context.currentProvider || context.hasSecondaryProviders ) { %>
+    <div class="login-providers">
+        <div class="section-title lines">
+            <h2>
+                <span class="text"><%- gettext("or sign in with") %></span>
+            </h2>
+        </div>
+
+        <% _.each( context.providers, function( provider ) {
+            if ( provider.loginUrl ) { %>
+                <button type="button" class="gym-button button-<%- provider.id %> login-provider login-<%- provider.id %>" data-provider-url="<%- provider.loginUrl %>">
+                    <div class="icon <% if ( provider.iconClass ) { %>fa <%- provider.iconClass %><% } %>" aria-hidden="true">
+                        <% if ( provider.iconImage ) { %>
+                            <img class="icon-image" src="<%- provider.iconImage %>" alt="<%- provider.name %> icon" />
+                        <% } %>
+                    </div>
+                    <span aria-hidden="true"><%- provider.name %></span>
+                    <span class="sr"><%- _.sprintf( gettext("Sign in with %(providerName)s"), {providerName: provider.name} ) %></span>
+                </button>
+            <% }
+        }); %>
+
+        <% if ( context.hasSecondaryProviders ) { %>
+            <button type="button" class="gym-button button-secondary-login form-toggle" data-type="institution_login">
+                <%- gettext("Use my institution/campus credentials") %>
+            </button>
+        <% } %>
+    </div>
+    <% } %>
+</form>
+
+<div class="toggle-form">
+    <div class="section-title">
+        <h2>
+            <span class="text"><%- _.sprintf( gettext("New to %(platformName)s?"), context ) %></span>
+        </h2>
+    </div>
+    <button class="gym-button form-toggle" data-type="register"><%- gettext("Create an account") %></button>
+</div>

--- a/lms/templates/student_account/login_and_register.html
+++ b/lms/templates/student_account/login_and_register.html
@@ -1,0 +1,46 @@
+<%!
+    import json
+    from django.utils.translation import ugettext as _
+    from openedx.core.djangolib.js_utils import dump_js_escaped_json
+%>
+<%namespace name='static' file='/static_content.html'/>
+
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Sign in or Register")}</%block>
+
+<%block name="js_extra">
+    <%static:require_module module_name="js/student_account/logistration_factory" class_name="LogistrationFactory">
+        var options = ${data | n, dump_js_escaped_json};
+        LogistrationFactory(options);
+        if ('newrelic' in window) {
+            newrelic.finished();
+            // Because of a New Relic bug, the finished() event doesn't show up
+            // in Insights, so we have to make a new PageAction that is basically
+            // the same thing. We still want newrelic.finished() for session
+            // traces though.
+            newrelic.addPageAction('xfinished');
+        }
+    </%static:require_module>
+</%block>
+
+<%block name="header_extras">
+    % for template_name in ["account", "access", "form_field", "login", "register", "institution_login", "institution_register", "password_reset", "hinted_login"]:
+        <script type="text/template" id="${template_name}-tpl">
+            <%static:include path="student_account/${template_name}.underscore" />
+        </script>
+% endfor
+</%block>
+
+<div class="section-bkg-wrapper">
+    <main id="main" aria-label="Content" tabindex="-1">
+        <div id="login-and-registration-container" class="login-register" style="background:transparent;" />
+    </main>
+</div>
+
+<% 
+  # in the function in student_account/views.py that renders this page,
+  # the footer is disabled.  Because we don't want to modify the edx-platform
+  # repo if we can avoid it, we'll manually insert a footer here. -MB
+%>
+<%include file="../footer.html" />

--- a/lms/templates/student_account/password_reset.underscore
+++ b/lms/templates/student_account/password_reset.underscore
@@ -1,0 +1,19 @@
+<div class="status submission-error hidden" aria-live="polite">
+    <h4 class="message-title"><%- gettext("An error occurred.") %></h4>
+    <ul class="message-copy"></ul>
+</div>
+
+<form id="password-reset" class="password-reset-form" tabindex="-1">
+
+    <div class="section-title lines">
+        <h2>
+            <span class="text"><%- gettext("Password assistance") %></span>
+        </h2>
+    </div>
+
+    <p class="action-label"><%- gettext("Please enter your email address below and we will send you instructions for setting a new password.") %></p>
+
+    <%= fields %>
+
+    <button type="submit" class="gym-button js-reset"><%- gettext("Reset my password") %></button>
+</form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -1,0 +1,76 @@
+<div class="status submission-error hidden" aria-live="polite">
+    <h4 class="message-title"><%- gettext("We couldn't create your account.") %></h4>
+    <ul class="message-copy"></ul>
+</div>
+
+<form id="register" class="register-form" autocomplete="off" tabindex="-1" style="background:white;">
+
+    <% if (context.errorMessage) { %>
+        <div class="status submission-error">
+            <h4 class="message-title"><%- gettext("An error occurred.") %></h4>
+            <ul class="message-copy"><%- context.errorMessage %></ul>
+        </div>
+    <% } %>
+
+    <% if (context.currentProvider) { %>
+        <div class="status" aria-hidden="false">
+            <p class="message-copy">
+                <%- _.sprintf( gettext("You've successfully signed into %(currentProvider)s."), context ) %>
+                <%- _.sprintf( gettext("We just need a little more information before you start learning with %(platformName)s."), context ) %>
+            </p>
+        </div>
+    <% } else if ( context.providers.length > 0 || context.hasSecondaryProviders ) {  %>
+        <div class="login-providers">
+            <div class="section-title lines">
+                <h2>
+                    <span class="text"><%- gettext("Create an account using") %></span>
+                </h2>
+            </div>
+            <%
+            _.each( context.providers, function( provider) {
+                if ( provider.registerUrl ) { %>
+                    <button type="button" class="gym-button button-<%- provider.id %> login-provider register-<%- provider.id %>" data-provider-url="<%- provider.registerUrl %>">
+                        <div class="icon <% if ( provider.iconClass ) { %>fa <%- provider.iconClass %><% } %>" aria-hidden="true">
+                            <% if ( provider.iconImage ) { %>
+                                <img class="icon-image" src="<%- provider.iconImage %>" alt="<%- provider.name %> icon" />
+                            <% } %>
+                        </div>
+                        <span aria-hidden="true"><%- provider.name %></span>
+                        <span class="sr"><%- _.sprintf( gettext("Create account using %(providerName)s."), {providerName: provider.name} ) %></span>
+                    </button>
+            <%  }
+            }); %>
+
+            <% if ( context.hasSecondaryProviders ) { %>
+                <button type="button" class="gym-button form-toggle" data-type="institution_login">
+                    <%- gettext("Use my institution/campus credentials") %>
+                </button>
+            <% } %>
+        </div>
+        <div class="section-title lines">
+            <h2>
+                <span class="text"><%- gettext("or create a new one here") %></span>
+            </h2>
+        </div>
+    <% } else { %>
+        <div class="section-title lines">
+            <h2>
+                <span class="text"><%- gettext("Create a new account") %></span>
+            </h2>
+        </div>
+    <% } %>
+
+    <%= context.fields %>
+
+    <button type="submit" class="gym-button js-register register-button"><%- gettext("Create your account") %></button>
+    <p class="note">* <%- gettext("Required field") %></p>
+</form>
+
+<div class="toggle-form">
+    <div class="section-title">
+        <h2>
+            <span class="text"><%- gettext("Already have an account?") %></span>
+        </h2>
+    </div>
+    <button class="gym-button form-toggle" data-type="login"><%- gettext("Sign in") %></button>
+</div>


### PR DESCRIPTION
This is an intermediary/temporary update.  We're sunsetting the "Career Center" page - in favor of a nav item that says "Jobs":
### Logged out
![image](https://cloud.githubusercontent.com/assets/1844496/23681702/0aa2658a-035e-11e7-8232-1d79cc902b9c.png)

### Logged in
![image](https://cloud.githubusercontent.com/assets/1844496/23681695/fb9e0cba-035d-11e7-9772-046e695d3bbb.png)

For now, that link just goes to a `/jobs` page, which is a replica of the content that the old career center page had, with a "Jobs" title, located [here](https://github.com/gymnasium/static-site-content/blob/gh-pages/jobs.html):
![image](https://cloud.githubusercontent.com/assets/1844496/23681723/22fadd38-035e-11e7-8d35-2f5a131b3712.png)
