### PR TITLE
Headway Changelog on Gymnasium

### DIFF
--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -1241,3 +1241,11 @@ code, code *
 		color:$gym-light-grey;
 	}
 }
+
+#HW_badge_cont {
+  left:-12px;
+}
+
+#HW_frame_cont {
+  left:255px;
+}

--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -1242,12 +1242,23 @@ code, code *
 	}
 }
 
+/* HEADWAY CHANGELOG STYLE RULES */
+
 #HW_badge_cont {
-  margin-top:-5px;
-  margin-left:-10px;
+  margin-top:-2px;
+  margin-left:197px;
 }
 
-#HW_frame_cont {
-  margin-left:275px;
-  margin-top:-15px;
+#HW_badge {
+  background: $gym-white;
+
+  &.HW_visible {
+    /* this rule is applied when there is a new changelog to read */
+    background: $gym-orange;
+  }
+}
+
+div#HW_frame_cont.HW_visible {
+  margin-left:25px;
+  margin-top:-16px;
 }

--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -1243,9 +1243,11 @@ code, code *
 }
 
 #HW_badge_cont {
-  left:-12px;
+  margin-top:-5px;
+  margin-left:-10px;
 }
 
 #HW_frame_cont {
-  left:255px;
+  margin-left:275px;
+  margin-top:-15px;
 }

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -148,6 +148,13 @@ from django.conf import settings
 
 </script>
 
+<script>
+  var HW_config = {
+    selector: ".navbar-header", // CSS selector where to inject the badge
+    account: "x8jR9J" // your account ID
+  };
+</script>
+<script async src="//cdn.headwayapp.co/widget.js"></script>
 
 ##intercom.io analytics
 


### PR DESCRIPTION
This PR adds a changelog from [headwayapp.co](https://headwayapp.co/) to Gymnasium:

![image](https://cloud.githubusercontent.com/assets/1844496/24349166/64f3cb78-1308-11e7-8fc1-dbcf70bf827e.png)

I'll get this to staging soon, but @jgagne if you've got time, feel free to critique the positioning / design of the notification/box as pictured above.