### PR TITLE
super hacky circlci integration

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+machine:
+  python:
+    version: 2.7.10
+
+dependencies:
+  pre:
+    - echo '[edxapp-server]' > ~/inventory
+    - echo $STAGING_SERVER >> ~/inventory
+
+deployment:
+  staging:
+    branch: [develop,/feature.*/]
+    commands:
+      - deactivate && cd ~ && git clone https://github.com/appsembler/configuration && cd configuration && git checkout appsembler/eucalyptus/master && pip install -r requirements.txt && cd playbooks  && wget https://gist.githubusercontent.com/tkeemon/a36bbc91c13e17425678f8c1f0f7a42a/raw/49e753a7eb93c64b80e715d35ee6ce8ca59ae267/aquent_deploy.yml && ansible-playbook -i ~/inventory --user $CIRCLE_USER aquent_deploy.yml

--- a/circle.yml
+++ b/circle.yml
@@ -11,4 +11,4 @@ deployment:
   staging:
     branch: [develop,/feature.*/]
     commands:
-      - deactivate && cd ~ && git clone https://github.com/appsembler/configuration && cd configuration && git checkout appsembler/eucalyptus/master && pip install -r requirements.txt && cd playbooks  && wget https://gist.githubusercontent.com/tkeemon/a36bbc91c13e17425678f8c1f0f7a42a/raw/49e753a7eb93c64b80e715d35ee6ce8ca59ae267/aquent_deploy.yml && ansible-playbook -i ~/inventory --user $CIRCLE_USER aquent_deploy.yml
+      - deactivate && ~/deploy/deploy_staging.sh

--- a/deploy/aquent_deploy.yml
+++ b/deploy/aquent_deploy.yml
@@ -15,7 +15,7 @@
     - name: checkout comprehensive theme
       git_2_0_1:
         dest: "/edx/app/edxapp/themes/gymnasium"
-        repo: "https://github.com/tkeemon/edx-theme"
+        repo: "https://github.com/gymnasium/edx-theme"
         version: "develop"
         accept_hostkey: yes 
       become_user: "{{ edxapp_user }}"

--- a/deploy/aquent_deploy.yml
+++ b/deploy/aquent_deploy.yml
@@ -1,0 +1,71 @@
+---
+# tmp hack to deploy aquent theme to staging
+
+- name: Update theme
+  hosts: all
+  become: True
+  gather_facts: True
+  vars_files: 
+  - roles/common_vars/defaults/main.yml
+  - roles/supervisor/defaults/main.yml
+  - roles/edxapp/defaults/main.yml
+  vars:
+    tmp: none
+  tasks:        
+    - name: checkout comprehensive theme
+      git_2_0_1:
+        dest: "/edx/app/edxapp/themes/gymnasium"
+        repo: "https://github.com/tkeemon/edx-theme"
+        version: "develop"
+        accept_hostkey: yes 
+      become_user: "{{ edxapp_user }}"
+      register: edxapp_theme_checkout
+      tags:
+        - install
+        - install:code
+
+    - name: Remove and recreate the staticfiles directory so nothing stale can exist
+      file:
+          path: "{{ edxapp_staticfile_dir }}"
+          state: "{{ item }}"
+          owner: "{{ edxapp_user }}"
+          group: "{{ common_web_group }}"
+          mode:  "0755"
+      when: celery_worker is not defined and not devstack
+      with_items: ['absent', 'directory']
+      tags:
+        - gather_static_assets
+        - assets
+
+# Gather assets using paver if possible
+    - name: "gather {{ item }} static assets with paver"
+      command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
+      when: celery_worker is not defined and not devstack and item != "lms-preview"
+      with_items: "{{ service_variants_enabled }}"
+      tags:
+        - gather_static_assets
+        - assets
+
+    - name: restart LMS and CMS
+      supervisorctl:
+        name: "edxapp:"
+        supervisorctl_path: "{{ supervisor_ctl }}"
+        config: "{{ supervisor_cfg }}"
+        state: restarted
+      become_user: "{{ supervisor_service_user }}"
+      when: celery_worker is not defined and not disable_edx_services
+      tags:
+        - manage
+
+    - name: ensure edxapp has started
+      supervisorctl:
+        name: "edxapp:"
+        supervisorctl_path: "{{ supervisor_ctl }}"
+        config: "{{ supervisor_cfg }}"
+        state: started
+      become_user: "{{ supervisor_service_user }}"
+      when: celery_worker is not defined and not disable_edx_services
+      tags:
+        - manage
+
+

--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd ~  
+git clone https://github.com/appsembler/configuration 
+cd configuration 
+git checkout appsembler/eucalyptus/master 
+pip install -r requirements.txt 
+cd playbooks  
+
+ansible-playbook -i ~/inventory --user $CIRCLE_USER ~/deploy/aquent_deploy.yml
+

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,9 @@
+import unittest
+
+class TestCircleCI(unittest.TestCase):
+    def test_assert(self):
+        self.assertEqual(1+1,2)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
We can use this as a starting point for getting CircleCI to deploy commits from this repo to your staging server. We'll need to do a bit of configuration on your end to get things working, but that shouldn't take too long.

For now, any pushing to the branches:
- develop
- feature/any-feature-name

will trigger CirclCI to deploy the pushed branch to the staging server. The deploy takes about five minutes, mostly due to the long time it takes for Django to collect the static assets. 

Things we can do to improve this integration:

- [ ] start using actual tests (right now, we're just doing assertEquals(1,1)
- [ ] cache some of the intermediate build/deploy steps
- [ ] probably some other stuff...