### PR TITLE
add symlinks to edx_ansible roles and libraries

### DIFF
--- a/deploy/deploy_staging.sh
+++ b/deploy/deploy_staging.sh
@@ -7,5 +7,10 @@ git checkout appsembler/eucalyptus/master
 pip install -r requirements.txt 
 cd playbooks  
 
+#link edx_ansible roles and libraries
+ln -s ~/configuration/playbooks/roles ~/edx-theme/deploy/roles
+ln -s ~/configuration/playbooks/library ~/edx-theme/deploy/library
+
+#deploy
 ansible-playbook -i ~/inventory --user $CIRCLE_USER ~/edx-theme/deploy/aquent_deploy.yml
 


### PR DESCRIPTION
Pretty self explanatory. This will allow Ansible to find the necessary roles and libraries for the deployment to staging. 