### PR TITLE
Fix some bad markup on catalog page

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -57,75 +57,39 @@
 
   <main id="main" class="container" aria-label="Content" tabindex="-1">  
     <div class="catalog-content row">
-      <div class="">
-        <div class="col-md-9 course-overview">
-          <section class="courses-container">
-            % if course_discovery_enabled:
-            <div id="discovery-form" role="search" aria-label="course" class="wrapper-search-context">
-              
-              <h1 id="discovery-message" class="col-md-8"></h1>
+      <div class="col-md-9 course-overview">
+        <section class="courses-container">
 
-              <form class="wrapper-search-input col-md-4">
-                <label for="discovery-input" class="sr">${_('Search for a course')}</label>
-                <input id="discovery-input" class="discovery-input" placeholder="${_('Search for a course')}" type="text"/>
-                <button type="submit" class="button postfix discovery-submit" title="${_('Search')}">
-                  <span class="icon fa fa-search" aria-hidden="true"></span>
-                  <div aria-live="polite" aria-relevant="all">
-                    <div id="loading-indicator" class="loading-spinner hidden">
-                      <span class="icon fa fa-spinner fa-spin" aria-hidden="true"></span>
-                      <span class="sr">${_('Loading')}</span>
-                    </div>
-                  </div>
-                </button>
-              </form>
+          <h1 id="full">
+            Full Courses
+          </h1>
+          <p class="hero">
+            All our full courses are taught by experienced practitioners and focused on in-demand skills and technologies. Each includes 3 to 6 hours of video instruction, quizzes, assignments, a final exam, and certification when you pass!
+          </p>
+          
+          <ul class="listing-courses">
+            <!-- course card underscore template is loaded here if course_discovery is set to true-->
+            
+            <!-- otherwise we use the following loop -->
+            %for course in courses:
+              <%include file="./catalog-course.html" args="course=course" />
+            %endfor
+          </ul>
 
-            </div>
+          <h1 id="gymshorts">
+            Gym Shorts
+          </h1>
+          <p class="hero">
+            Gym Shorts are short, snackable courses that all last under an hour. Like our longer courses, they are practical, taught by experienced practitioners, and focused on in-demand skills and technologies.
+          </p>
+          <ul class="listing-courses" id="gym-shorts-list">
 
-            <div id="filter-bar" class="filters hide-phone is-collapsed">
-            </div>
-            % endif
-
-            <h1 id="full">
-              Full Courses
-            </h1>
-            <p class="hero">
-                All our full courses are taught by experienced practitioners and focused on in-demand skills and technologies. Each includes 3 to 6 hours of video instruction, quizzes, assignments, a final exam, and certification when you pass!
-            </p>
-            <div class="courses${'' if course_discovery_enabled else ' no-course-discovery'}" role="region" aria-label="${_('List of Courses')}">
-              <ul class="courses-listing">
-                <!-- course card underscore template is loaded here if course_discovery is set to true-->
-                
-                <!-- otherwise we use the following loop -->
-                %for course in courses:
-                  <%include file="./catalog-course.html" args="course=course" />
-                %endfor
-              </ul>
-            </div>
-
-            <h1 id="gymshorts">
-              Gym Shorts
-            </h1>
-            <p class="hero">
-              Gym Shorts are short, snackable courses that all last under an hour. Like our longer courses, they are practical, taught by experienced practitioners, and focused on in-demand skills and technologies.
-            </p>
-            <ul class="listing-courses" id="gym-shorts-list">
-
-            </ul>
-
-            % if course_discovery_enabled:
-            <aside aria-label="${_('Refine Your Search')}" class="search-facets phone-menu">
-              <h2 class="header-search-facets">${_('Refine Your Search')}</h2>
-              <section class="search-facets-lists">
-              </section>
-            </aside>
-            % endif
-
-          </section>
-        </div>
+          </ul>
+        </section>
+      </div>
       <div class="col-md-3 sidebar">
-          ## include sidebar content from git repo
-          ${_(urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/upcoming-courses.html').read())}
-        </div>  
+        ## include sidebar content from git repo
+        ${_(urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/upcoming-courses.html').read())}
       </div>
     </div> 
   </main>
@@ -154,6 +118,6 @@
           $(elem).remove();
         }
       });
-    }
-  })
+    };
+  });
 </script>


### PR DESCRIPTION
This was causing the rogue `GYM` element on firefox, and broken anchor links for the shortcut to "Gym Shorts"
Fix GYMX-363