### PR TITLE
Move headway changelog to a link in the footer

### DIFF
--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -1245,8 +1245,8 @@ code, code *
 /* HEADWAY CHANGELOG STYLE RULES */
 
 #HW_badge_cont {
-  margin-top:-2px;
-  margin-left:197px;
+  top: -30px;
+  left: 50px;
 }
 
 #HW_badge {
@@ -1260,5 +1260,5 @@ code, code *
 
 div#HW_frame_cont.HW_visible {
   margin-left:25px;
-  margin-top:-16px;
+  margin-top:0px;
 }

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -9,12 +9,12 @@
   <footer class="container">
     <div class="row">
       <nav>
-        <div class="col-md-4">
+        <div class="col-md-3">
           <a href="${marketing_link('ROOT')}">
             <img class="gymnasium-logo"  src="${static.url('images/gymnasiumLogo.png')}" alt="Aquent Gymnasium" >
           </a>
         </div>
-        <div class="col-md-4">
+        <div class="col-md-6">
           <ol class="list-inline text-center footer-link-list">
             <li><a href="https://medium.com/gymnasium" target="_blank">Blog</a></li>
             <li><a href="${reverse('jobs')}">Jobs</a></li>
@@ -22,12 +22,15 @@
             <li><a href="${marketing_link('FAQ')}">FAQ</a></li>
             <li><a href="${reverse('support')}">Support</a></li>
             <li><a href="${reverse('privacy')}">Privacy Policy</a></li>
+            <li id="headway-changelog-anchor">
+              <a href="https://headwayapp.co/gymnasium-changelog" target="_blank">Changelog</a>
+            </li>
           </ol>
           <div class="copyright">&copy; ${current_year} Aquent Gymnasium</div>
         </div>
       </nav>
 
-      <div class="built-on col-md-4 text-center">
+      <div class="built-on col-md-3 text-center">
         <span>
           <a href="http://openedx.org" target="_blank">
             <img

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -150,7 +150,7 @@ from django.conf import settings
 
 <script>
   var HW_config = {
-    selector: ".navbar-header", // CSS selector where to inject the badge
+    selector: "#headway-changelog-anchor", // CSS selector where to inject the badge
     account: "x8jR9J" // your account ID
   };
 </script>


### PR DESCRIPTION
Just like the title says - changelog moves to a link in the footer.  The notification icon for the changelog is also now attached to the same footer link.