### PR TITLE
Fix course title tab repetitions

### DIFF
--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -21,11 +21,7 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
 <%block name="title">
   <title>
-      % if section_title:
-        ${static.get_page_title_breadcrumbs(section_title, course_name())}
-      % else:
-        ${static.get_page_title_breadcrumbs(course_name())}
-      %endif
+    ${static.get_page_title_breadcrumbs(course_name())}
   </title>
 </%block>
 


### PR DESCRIPTION
# fixes 
- GYMX-293: Course section titles were repeated in courseware.  This stops the repetition.

before:
![image](https://cloud.githubusercontent.com/assets/1844496/25632119/77a20c68-2f40-11e7-87d9-76e8ae03a2f5.png)

after:
(forgot to take a screenshot - but the section name should not be repeated)