### PR TITLE
Tracking events in intercom- register/enroll/unenroll 

### DIFF
--- a/lms/static/js/gymnasium.js
+++ b/lms/static/js/gymnasium.js
@@ -617,6 +617,7 @@ Gymnasium.prototype.RecordRegistration = function(emailAddress, firstName, lastN
     PROC:             "AWUISubmitExternalLead"
   };
 
+  Intercom('trackEvent', 'registration', data);
   return Gymnasium.RecordCloudwallRecord(data, callback);
 };
 

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -55,9 +55,12 @@ from edxmako.shortcuts import marketing_link
           //success - log the event in Intercom
           var metadata = {
             "course_id" : "${course.display_number_with_default}",
-            "course_name" : "${course.display_name_with_default}"
+            "course_name" : "${course.display_name_with_default}",
+            "email": "${user.email}",
+            "name": "${user.profile.name}",
+            "username": "${user.username}",
           };
-          Intercom('trackEvent', 'enrolled', metadata);
+          Intercom('trackEvent', 'GYM${course.display_number_with_default}-enroll', metadata);
 
           if (xhr.responseText == "") {
             

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -45,38 +45,43 @@ from openedx.core.djangolib.markup import HTML, Text
         signInUser: "${reverse('signin_user') | n, js_escaped_string}",
         changeEmailSettings: "${reverse('change_email_settings') | n, js_escaped_string}"
       });
-    });
 
-    //hide "BETA" from courses that have it in their title,
-    //and add .beta class to corresponsing <li> itm
-    $('.listing-courses li').each(function(idx, obj){
-      var beta_tag = "beta";
-      var beta_class_name="beta";
+      //hide "BETA" from courses that have it in their title,
+      //and add .beta class to corresponsing <li> itm
+      $('.listing-courses li').each(function(idx, obj){
+        var beta_tag = "beta";
+        var beta_class_name="beta";
 
-      var course_title_obj = $(obj).find('h1')
-      var course_title = $(course_title_obj).text().trim();
+        var course_title_obj = $(obj).find('h1')
+        var course_title = $(course_title_obj).text().trim();
 
-      //check to see if this course is a BETA course
-      if (course_title.toLowerCase().indexOf(beta_tag) >= 0)
-      {
-        //this is a beta Course
-        //strip the "BETA" word from the title
-        course_title = course_title.substr(beta_tag.length).trim();
-        console.log('course title is now', course_title);
+        //check to see if this course is a BETA course
+        if (course_title.toLowerCase().indexOf(beta_tag) >= 0)
+        {
+          //this is a beta Course
+          //strip the "BETA" word from the title
+          course_title = course_title.substr(beta_tag.length).trim();
+          console.log('course title is now', course_title);
 
-        course_title_obj.text(course_title);
+          course_title_obj.text(course_title);
 
-        $(obj).addClass(beta_class_name);
+          $(obj).addClass(beta_class_name);
+        }
+      });
+      
+      $('#unenroll-button').click(function(){
+        var courseNum = $('#unenroll_course_number').text();
+        var eventName = 'gym' + courseNum + '-unenroll';
+        var metadata = {
+          "course_id" : $('#unenroll_course_number').text(),
+          "course_name": $('#unenroll-course-name').text(),
+          "email": "${user.email}",
+          "name": "${user.profile.name}",
+          "username": "${user.username}",
+        };
 
-      }
-    });
-
-    $('#unenroll-button').submit(function(){
-      var metadata = {
-        "course_id" : $('#unenroll_course_number').text(),
-        "course_name": $('#unenroll-course-name').text()
-      };
-      Intercom('trackEvent', 'unenroll', metadata);
+        Intercom('trackEvent', eventName, metadata);
+      });
     });
   </script>
   % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -128,6 +128,7 @@ from student.helpers import (
                   document.getElementById('track-info').innerHTML='${_("Are you sure you want to unenroll from")}';
                   document.getElementById('refund-info').innerHTML='';
                   document.getElementById('unenroll-course-name').innerHTML='${course_overview.display_name_with_default | h}';
+                  document.getElementById('unenroll_course_number').innerHTML='${course_overview.number | h}';
                   $('#unenroll_course_id').val('${course_overview.id | h}');
                 ">
                 ${_('Unenroll')}


### PR DESCRIPTION
This PR Includes an update to our integration with Intercom.  Behaviors are added for:
- [x] user registration
- [x] course enrollment
- [x] course unenrollment
- [ ] final exam submissions (this one is turning out to be a pain, surprise surprise).

# To test:
1. on [staging](http://courses.gymna.si), test one of the above events by logging into an account, and enrolling in a course.
2. Log into Intercom, and select our test app:
![image](https://user-images.githubusercontent.com/1844496/27284235-da1bff3e-54c5-11e7-9955-13c5f2c90ac1.png)

Note: when you're on the test app, you'll see a black/yellow "construction" bar above the intercom icon:
![image](https://user-images.githubusercontent.com/1844496/27284262-e799e22a-54c5-11e7-8d45-606344be2af3.png)


3. In the "people" section of intercom, find the account you've just enrolled in a course with (or unenrolled, etc).  
<img width="1614" alt="pasted_image_6_19_17__8_05_am" src="https://user-images.githubusercontent.com/1844496/27284332-2c9a290c-54c6-11e7-847c-b489450cc235.png">


4. Click on that account to get to its details page.
![image](https://user-images.githubusercontent.com/1844496/27284300-10696572-54c6-11e7-8f8b-daed2a6641ec.png)

5. You'll see some events being registered in intercom.  Confirm that they meet your expectations, and that metadata is correct:
![image](https://user-images.githubusercontent.com/1844496/27284220-cd27bb6a-54c5-11e7-829a-990c55f47ee4.png)
