### PR TITLE
Static site content added to dashboard

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -10,6 +10,7 @@ import third_party_auth
 from third_party_auth import pipeline
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
+import urllib2
 %>
 
 <%
@@ -120,10 +121,15 @@ from openedx.core.djangolib.markup import HTML, Text
   </header>
 </div>
 
+
 <main id="main" aria-label="Content" tabindex="-1" class="content-wrapper">
     <section class="container course-content" id="dashboard-main">
       <div class="row">
         <section class="my-courses col-md-9" id="my-courses">
+
+          <div class="dashboard-custom-content">
+            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/dashboard.html').read() | n}
+          </div>
 
           <header class="hero">
             <h1>${_("My Courses")}</h1>


### PR DESCRIPTION
Content is pulled from [here](https://github.com/gymnasium/static-site-content/blob/gh-pages/dashboard.html), and is displayed on `/dashboard`, at the top of the left-hand column:

![image](https://user-images.githubusercontent.com/1844496/27302378-df49d32a-5504-11e7-9a74-aa81c3e5bab9.png)
