### PR TITLE
Home page bug fixes

### DIFF
--- a/lms/static/js/gymnasium.js
+++ b/lms/static/js/gymnasium.js
@@ -521,6 +521,7 @@ Gymnasium.prototype.LoadJobsForMarket = function(selected_market, limit, page, c
     {
       var market = getMarketFromGeoLocation(position);
       queryJobsForMarket(market.id);
+      $('#find-jobs-market-name, .job-location').text(market.name);
     }
 
     // get user's Market name (ie. "Chicago")

--- a/lms/static/sass/_home.scss
+++ b/lms/static/sass/_home.scss
@@ -552,6 +552,7 @@
   .tagline
   {
     margin-bottom:1em;
+    margin-top:1.5em;
 
     h2
     {

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -188,7 +188,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
 
               <div class="row">
                 <div class="col-md-6 col-md-offset-3 text-center">
-                  <a href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=viewall" class="view-all-jobs">
+                  <a id="view-jobs-link" target="_blank" href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=viewall&l=10" class="view-all-jobs">
                     View all jobs in <var class="job-location"> Boston</var>
                   </a>
                 </div>
@@ -287,6 +287,11 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
            event.preventDefault();
            var market = $('#market').val();
            var market_label = $('#market option:selected').text();
+
+           // update the "View all jobs in [market]" url to point to this market
+           var viewJobsLinkURL = 'http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=viewall&l=' + market;
+           var viewJobsLink = $('#view-jobs-link')[0];
+           viewJobsLink.href = viewJobsLinkURL;
 
            Gymnasium.LoadJobsForMarket(market);
            $('#find-jobs-market-name, .job-location').text(market_label);

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -187,8 +187,8 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
               </ul>
 
               <div class="row">
-                <div class="col-md-4 col-md-offset-4">
-                  <a href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=viewall" class="text-center view-all-jobs">
+                <div class="col-md-6 col-md-offset-3 text-center">
+                  <a href="http://aquent.com/find-work/?utm_source=gymnasium&utm_medium=web&utm_campaign=homepagejobs&utm_content=viewall" class="view-all-jobs">
                     View all jobs in <var class="job-location"> Boston</var>
                   </a>
                 </div>


### PR DESCRIPTION
# This PR fixes:
- GYMX-355: header to subheader vertical spacing for "Find jobs" module on home page
- GYMX-356: View all jobs in "Market Location" link doesn't pass location value
- GYMX-357: Find Work: View all jobs link wraps to second line