### PR TITLE
Open graph tags for courses

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -11,7 +11,8 @@ from edxmako.shortcuts import marketing_link
 <%block name="headextra">
   ## OG (Open Graph) title and description added below to give social media info to display
   ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta property="og:title" content="${course.display_name_with_default_escaped}" />
+  <meta property="og:title" content="${course.display_name_with_default_escaped} - Gymnasium" />
+  <meta property="og:image" content="${course_image_urls['large']}" />
 </%block>
 
 <%block name="js_extra">

--- a/lms/templates/courseware/courseware.html
+++ b/lms/templates/courseware/courseware.html
@@ -9,6 +9,7 @@ from django.conf import settings
 from edxnotes.helpers import is_feature_enabled as is_edxnotes_enabled
 from openedx.core.djangolib.markup import HTML
 from openedx.core.djangolib.js_utils import js_escaped_string
+from openedx.core.lib.courses import course_image_url
 %>
 <%
   include_special_exams = settings.FEATURES.get('ENABLE_SPECIAL_EXAMS', False) and (course.enable_proctored_exams or course.enable_timed_exams)
@@ -53,6 +54,10 @@ from openedx.core.djangolib.js_utils import js_escaped_string
 
 
 <%block name="headextra">
+  ## OG (Open Graph) title and description added below to give social media info to display
+  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
+  <meta property="og:title" content="${course.display_name_with_default_escaped} - Gymnasium" />
+  <meta property="og:image" content="${course_image_url(course, 'course_image')}" />
   <%static:css group='style-course-vendor'/>
   <%static:css group='style-course'/>
   

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -6,16 +6,22 @@
 from django.utils.translation import ugettext as _
 
 from courseware.courses import get_course_info_section, get_course_date_summary
+from openedx.core.lib.courses import course_image_url
 
 from openedx.core.djangoapps.self_paced.models import SelfPacedConfiguration
 from openedx.core.djangolib.markup import HTML, Text
+
 %>
 
 <%block name="pagetitle">${_("{course_name}").format(course_name=course.display_name_with_default)}</%block>
 
 <%block name="headextra">
-<%static:css group='style-course-vendor'/>
-<%static:css group='style-course'/>
+  <%static:css group='style-course-vendor'/>
+  <%static:css group='style-course'/>
+  ## OG (Open Graph) title and description added below to give social media info to display
+  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
+  <meta property="og:title" content="${course.display_name_with_default_escaped} - Gymnasium" />
+  <meta property="oh:image" content="${course_image_url(course, 'course_image')}" />
 </%block>
 
 % if show_enroll_banner:

--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -5,12 +5,8 @@
 from django.conf import settings
 %>
 
-<meta property="og:url" content="http://thegymnasium.com/" />
-<meta property="og:title" content="Aquent Gymnasium" />
-<meta property="og:image" content="${static.url('images/social-share-400.png')}" />
 <meta property="og:description" content="At Aquent Gymnasium, we offer free online courses focused on HTML and CSS, responsive design, UX design, and an array of front-end development tools." />
-<meta property="og:keywords" content="free online courses" />
-
+<meta property="og:keywords" content="free online courses designers design user experience UX javascript node nodejs sketch wordpress drupal UI" />
 
 <!-- insert typekit font references -->
 <script src="//use.typekit.net/rhf0qta.js"></script>

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -10,6 +10,12 @@
 
 <%block name="pagetitle">${_("Home")}</%block>
 
+<%block name="headextra">
+  <meta property="og:url" content="http://thegymnasium.com/" />
+  <meta property="og:title" content="Aquent Gymnasium" />
+  <meta property="og:image" content="${static.url('images/social-share-400.png')}" />
+</%block>
+
 
 <!--
 Start of DoubleClick Floodlight Tag: Please do not remove


### PR DESCRIPTION
# What this PR does
- adds Open graph image and title tags for courses on:
  - catalog about pages
  - courseware pages
  - syllabus pages

- moves OG tags that we were using before _just_ to the home page. I need to come up with a list of pages missing OG tags after this PR is deployed and working

# Notes
- Though this _should_ add an image and title to Open Graph shares, it will not add a course description... pretty much because we don't have one without markup embedded in it (since we use the `course_short_description` as a placeholder for some `<ul>`s). Embedded HTML is not good/allowed in OG tags, and it messes up page templates if I try anyway, so :sheep:
