### PR TITLE
Use correct github pages links

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -91,7 +91,7 @@
         <%include file='../jobs/find_jobs.html' />
 
         ## include sidebar content from git repo
-        ${_(urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/upcoming-courses.html').read())}
+        ${_(urllib2.urlopen('https://gymnasium.github.io/static-site-content/upcoming-courses.html').read())}
       </div>
     </div> 
   </main>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -128,7 +128,7 @@ import urllib2
         <section class="my-courses col-md-9" id="my-courses">
 
           <div class="dashboard-custom-content">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/dashboard.html').read() | n}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/dashboard.html').read() | n}
           </div>
 
           <header class="hero">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -36,7 +36,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
 
 
 <section class="home">
-  ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/home/hero.html').read()}
+  ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/hero.html').read()}
 
   <section class="container-fluid subsection">
     <div class="container">
@@ -69,7 +69,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
           </header>
 
           <section class="courses row">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/home/featured-courses.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/featured-courses.html').read()}
           </section>
         </section>
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -244,7 +244,7 @@
 
       </div>
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/login-sidebar.html').read()}
+        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/login-sidebar.html').read()}
       </div>
     </div>
   </div>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -149,9 +149,9 @@ site_status_msg = get_site_status_msg(course_id)
   </header>
 
   % if settings.PLATFORM_NAME == "Gymnasium STAGING":
-    ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/system_status/staging.html').read()}
+    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/staging.html').read()}
   % else:
-    ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/system_status/production.html').read()}
+    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/production.html').read()}
   % endif
 
 % if course:

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -171,7 +171,7 @@ import urllib2
       </div>
       
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/register-sidebar.html').read()}
+        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/register-sidebar.html').read()}
       </div>
     </div>
   </div>

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -28,7 +28,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/about.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/about.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/careers.html
+++ b/lms/templates/static_templates/careers.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/careers.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/careers.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/faq.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/faq.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include jobs page from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/jobs.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/jobs.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/support.html
+++ b/lms/templates/static_templates/support.html
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/support.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/support.html').read()}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/theme-upcoming-content.html
+++ b/lms/templates/static_templates/theme-upcoming-content.html
@@ -1,2 +1,2 @@
 <% import urllib2 %>
-${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/static-pages-sidebar-content.html').read()}
+${urllib2.urlopen('https://gymnasium.github.io/static-site-content/static-pages-sidebar-content.html').read()}

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://raw.githubusercontent.com/gymnasium/static-site-content/gh-pages/privacy-policy.html').read()}
+            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
           </div>
 
           <div class="col-md-3">


### PR DESCRIPTION
This fixes a potential issue with access to static content we're pulling from github.  Using `raw.githubusercontent` is not the recommended way to pull this data.