### PR TITLE
One more copy tweak

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -48,7 +48,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
         <div class="col-md-4 col-sm-12 col-xs-12">
           <h2>Free Online Courses</h2>
           <p>
-            We offer free online courses designed to empower creative professionals with marketable skills.
+            We offer free online courses designed to empower creative professionals.
           </p>
         </div>
 


### PR DESCRIPTION
Per Keir's request:

> can we cut off the first section after "empower creative professionals." and ditch "with marketable skills." ?