### PR TITLE
Move Gymnasium to github.io CMS

### DIFF
--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -2,6 +2,7 @@
 <%inherit file="main.html" />
 <%def name="online_help_token()"><% return "learnerdashboard" %></%def>
 <%namespace name='static' file='static_content.html'/>
+<%namespace name="gymcms" file="./util/gymcms.mako" />
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -10,7 +11,6 @@ import third_party_auth
 from third_party_auth import pipeline
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
 from openedx.core.djangolib.markup import HTML, Text
-import urllib2
 %>
 
 <%
@@ -128,7 +128,7 @@ import urllib2
         <section class="my-courses col-md-9" id="my-courses">
 
           <div class="dashboard-custom-content">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/dashboard.html').read() | n}
+            ${gymcms.render('dashboard')}
           </div>
 
           <header class="hero">

--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -1,11 +1,10 @@
 <%! from django.utils.translation import ugettext as _ %>
 
 <%! from django.core.urlresolvers import reverse %>
-<% import urllib2 %>
 
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
-
+<%namespace name='gymcms' file='./util/gymcms.mako' />
 
 
 <%block name="pagetitle">${_("Home")}</%block>
@@ -36,7 +35,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
 
 
 <section class="home">
-  ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/hero.html').read()}
+  ${gymcms.render('home/hero')}
 
   <section class="container-fluid subsection">
     <div class="container">
@@ -75,7 +74,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
           </header>
 
           <section class="courses row">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/home/featured-courses.html').read()}
+            ${gymcms.render('home/featured-courses')}
           </section>
         </section>
 

--- a/lms/templates/login.html
+++ b/lms/templates/login.html
@@ -1,12 +1,13 @@
 <%inherit file="main.html" />
 <%! from microsite_configuration import microsite %>
 <%namespace name='static' file='static_content.html'/>
+<%namespace name='gymcms' file='./util/gymcms.mako' />
 
 <%! from django.core.urlresolvers import reverse %>
 <%! from django.utils.translation import ugettext as _ %>
 <%! import third_party_auth %>
 <%! from third_party_auth import provider, pipeline %>
-<% import urllib2 %> 
+
 
 <%block name="pagetitle">${_("Log into your {platform_name} Account").format(platform_name=platform_name)}</%block>
 
@@ -244,7 +245,7 @@
 
       </div>
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/login-sidebar.html').read()}
+        ${gymcms.render('sidebar-login')}
       </div>
     </div>
   </div>

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -1,6 +1,7 @@
 ## mako
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
+<%namespace name='gymcms' file='./util/gymcms.mako' />
 <%!
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext as _
@@ -11,7 +12,7 @@ import branding
 from status.status import get_site_status_msg
 %>
 
-<% import urllib2 %>
+<% import json %>
 
 ## Provide a hook for themes to inject branding on top.
 <%block name="navigation_top" />
@@ -148,11 +149,7 @@ site_status_msg = get_site_status_msg(course_id)
     </div>
   </header>
 
-  % if settings.PLATFORM_NAME == "Gymnasium STAGING":
-    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/staging.html').read()}
-  % else:
-    ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/system_status/production.html').read()}
-  % endif
+  ${gymcms.render('system-status')}
 
 % if course:
 <!--[if lte IE 8]>

--- a/lms/templates/register.html
+++ b/lms/templates/register.html
@@ -1,6 +1,7 @@
 <%inherit file="main.html" />
 <%namespace name='static' file='static_content.html'/>
 <%namespace file='main.html' import="login_query"/>
+<%namespace file="./util/gymcms.mako" />
 <%!
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
@@ -11,7 +12,6 @@ from datetime import date
 import third_party_auth
 from third_party_auth import pipeline, provider
 import calendar
-import urllib2
 %>
 
 <%block name="pagetitle">${_("Register for {platform_name}").format(platform_name=platform_name)}</%block>
@@ -171,7 +171,7 @@ import urllib2
       </div>
       
       <div class="col-md-3 additional-information">
-        ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/register-sidebar.html').read()}
+        ${gymcms.render('sidebar-register'}
       </div>
     </div>
   </div>

--- a/lms/templates/static_templates/about.html
+++ b/lms/templates/static_templates/about.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("About")}</%block>
 
@@ -28,7 +28,7 @@ document.write('<iframe src="https://5255816.fls.doubleclick.net/activityi;src=5
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/about.html').read()}
+            ${gymcms.render('about')}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/careers.html
+++ b/lms/templates/static_templates/careers.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("Career Center")}</%block>
 <div class="container ">
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/careers.html').read()}
+            ${gymcms.render('careers')}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/faq.html
+++ b/lms/templates/static_templates/faq.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("FAQ")}</%block>
 <div class="container ">
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/faq.html').read()}
+            ${gymcms.render('faq')}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/honor.html
+++ b/lms/templates/static_templates/honor.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("Privacy Policy")}</%block>
 <div class="container ">
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
+            ${gymcms.render('faq')}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/jobs.html
+++ b/lms/templates/static_templates/jobs.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("Jobs")}</%block>
 <div class="container ">
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include jobs page from git repo
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/jobs.html').read()}
+            ${gymcms.render('jobs')}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/news.html
+++ b/lms/templates/static_templates/news.html
@@ -1,6 +1,5 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
 
 <%block name="pagetitle">${_("News &amp; Events")}</%block>
 <div class="container ">

--- a/lms/templates/static_templates/privacy.html
+++ b/lms/templates/static_templates/privacy.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("Privacy Policy")}</%block>
 <div class="container ">
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
+            ${gymcms.render('privacy-policy')}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/static_templates/support.html
+++ b/lms/templates/static_templates/support.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("FAQ")}</%block>
 <div class="container ">
@@ -9,7 +9,7 @@
       <div class="white-panel">
         <div class="row">
           <div class="col-md-9">
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/support.html').read()}
+            ${gymcms.render('support')}
           </div>
           <div class="col-md-3">
             <%include file="theme-upcoming-content.html" />

--- a/lms/templates/static_templates/theme-upcoming-content.html
+++ b/lms/templates/static_templates/theme-upcoming-content.html
@@ -1,2 +1,2 @@
-<% import urllib2 %>
-${urllib2.urlopen('https://gymnasium.github.io/static-site-content/static-pages-sidebar-content.html').read()}
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+${gymcms.render('sidebar-generic')}

--- a/lms/templates/static_templates/tos.html
+++ b/lms/templates/static_templates/tos.html
@@ -1,6 +1,6 @@
 <%! from django.utils.translation import ugettext as _ %>
 <%inherit file="../main.html" />
-<% import urllib2 %>
+<%namespace name="gymcms" file="../util/gymcms.mako" />
 
 <%block name="pagetitle">${_("Privacy Policy")}</%block>
 <div class="container ">
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="col-md-9">
             ## include privacy policy from git repo
-            ${urllib2.urlopen('https://gymnasium.github.io/static-site-content/privacy-policy.html').read()}
+            ${gymcms.render('privacy-policy')}
           </div>
 
           <div class="col-md-3">

--- a/lms/templates/util/gymcms.mako
+++ b/lms/templates/util/gymcms.mako
@@ -1,0 +1,11 @@
+<%def name="render(templateUrl)">
+  <% import urllib2 %>
+  <% from django.conf import settings %>
+  %if templateUrl:
+    %if settings.FEATURES.get('ENVIRONMENT') == "staging":
+      ${urllib2.urlopen('https://staging.gymcms.xyz/static/' + templateUrl).read()}
+    %elif settings.FEATURES.get('ENVIRONMENT') == "production":
+      ${urllib2.urlopen('https://gymcms.xyz/static/' + templateUrl).read()}
+    %endif
+  %endif
+</%def>

--- a/lms/templates/util/gymcms.mako
+++ b/lms/templates/util/gymcms.mako
@@ -4,7 +4,7 @@
   %if templateUrl:
     %if settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "staging":
       ${urllib2.urlopen('https://staging.gymcms.xyz/static/' + templateUrl).read()}
-    %if settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "production":
+    %elif settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "production":
       ${urllib2.urlopen('https://gymcms.xyz/static/' + templateUrl).read()}
     %endif
   %endif

--- a/lms/templates/util/gymcms.mako
+++ b/lms/templates/util/gymcms.mako
@@ -2,9 +2,9 @@
   <% import urllib2 %>
   <% from django.conf import settings %>
   %if templateUrl:
-    %if settings.FEATURES.get('ENVIRONMENT') == "staging":
+    %if settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "staging":
       ${urllib2.urlopen('https://staging.gymcms.xyz/static/' + templateUrl).read()}
-    %elif settings.FEATURES.get('ENVIRONMENT') == "production":
+    %if settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "production":
       ${urllib2.urlopen('https://gymcms.xyz/static/' + templateUrl).read()}
     %endif
   %endif


### PR DESCRIPTION
(Note: several PRs coming - it's turning out to be easier to split them up into individual featuresets)

# What this does
- This PR switches all of our imports to our new, jekyll-based CMS.
- removes several unnecessary imports of `urllib2` from various template pages
- creates a special mako template to import from our CMS server-side

# Important
- this PR requires an environment variable called `ENVIRONMENT` to be set to `staging` or `production` in order to work correctly.  This might need to be adapted.  Will ping TJ to confirm.