### PR TITLE
Change header "Sign up for an account" button to "Sign up"

### DIFF
--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -120,7 +120,7 @@ site_status_msg = get_site_status_msg(course_id)
                   <li>
                     % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
                         % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
-                        <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}"><b>${_("Log in")}</b></a>
+                        <a class="cta cta-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}"><b>${_("Log In")}</b></a>
                         % else:
                         <a class="gym-button" href="/login${login_query()}"><b>${_("Log in")}</b></a>
                         % endif

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -45,7 +45,7 @@ site_status_msg = get_site_status_msg(course_id)
             <div class="nav navbar navbar-nav navbar-left">
               % if not user.is_authenticated():
                   % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
-                    <a class="gym-button" href="/register"><b>${_("Sign up for an account")}</b></a>
+                    <a class="gym-button" href="/register"><b>${_("Sign Up")}</b></a>
                   % endif
                 % endif
             </div>


### PR DESCRIPTION
# What this PR Does
- Per our discussion today on the homepage regroup call, this PR changes the button in the header of the site to just say "Sign Up".  I've suggested some alternatives that might look a little nicer, too.

# Screenshots

## Before:
![image](https://user-images.githubusercontent.com/1844496/38569473-5e5e7570-3cb9-11e8-9e17-09d32d9e8c8a.png)

## After
![image](https://user-images.githubusercontent.com/1844496/38569521-783f8d12-3cb9-11e8-8258-848da7049bf0.png)

## Sign up (It's free) version
![image](https://user-images.githubusercontent.com/1844496/38569537-8075cbe0-3cb9-11e8-92d1-a79abadd8110.png)


## Sign up Now version
![image](https://user-images.githubusercontent.com/1844496/38569488-672a2c3a-3cb9-11e8-932a-328833250a99.png)
