### PR TITLE
Prep for course badging release

### DIFF
--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -334,6 +334,12 @@ body.register,
 	a:link:visited,
 	a:active,
 	a:link:active,
+	p a,
+	p a:link,
+	p a:visited,
+	a.gymlink,
+	a.gymlink:link,
+	a.gymlink:visited
 	{		
 		color: $gym-orange;
 		font-family:$theme-serif-font;
@@ -352,7 +358,10 @@ body.register,
 	.dashboard .my-courses .course .info>hgroup h3 span:hover,
 	.dashboard .my-courses .course .info>hgroup h3 span:focus,
 	p a:link:hover,
-	p a:hover
+	p a:hover,
+	a.gymlink:hover,
+	a.gymlink:link:hover,
+	a.gymlink:visited:hover
 	{
 		border-bottom:1px solid $gym-orange;
 		color:$gym-orange;

--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -80,7 +80,7 @@
             Gym Shorts
           </h1>
           <p class="hero">
-            Gym Shorts are short, snackable courses that all last under an hour. Like our longer courses, they are practical, taught by experienced practitioners, and focused on in-demand skills and technologies.
+            Gym Shorts are short courses that all last under an hour. Like our full courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
           </p>
           <ul class="listing-courses" id="gym-shorts-list">
 

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -14,7 +14,7 @@ from openedx.core.djangolib.markup import HTML, Text
 %>
 
 <%
-  cert_name_short = settings.CERT_NAME_SHORT
+  cert_name_short = "certificate"
   cert_name_long = settings.CERT_NAME_LONG
 %>
 

--- a/lms/templates/dashboard/_dashboard_certificate_information.html
+++ b/lms/templates/dashboard/_dashboard_certificate_information.html
@@ -71,7 +71,7 @@ else:
   <ul class="actions actions-secondary">
       <li class="action action-share">
         <a class="action-linkedin-profile" target="_blank" href="${cert_status['linked_in_url']}"
-         title="${_('Add Certificate to LinkedIn Profile')}"
+         title="${_('Add certificate to LinkedIn Profile')}"
          data-course-id="${course_overview.id}"
          data-certificate-mode="${cert_status['mode']}"
         >

--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -115,7 +115,7 @@ from student.helpers import (
             <li>
               <li class="action action-certificate">
               <a href="${cert_status['download_url']}"
-                title="${_('This link will open/download a PDF document')}">
+                title="${_('View your certificate')}">
                 ${_("My {cert_name_short}").format(cert_name_short=cert_name_short)}</a></li>
             </li>
           % endif

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -18,7 +18,7 @@ from openedx.core.djangolib.markup import HTML
       <h2>Congratulations!</h2>
       <p>Congratulations on completing the course and passing the final exam with flying colors. You really know your stuff!</p>
 
-      <p>Show off to your friends and colleagues by downloading your Certificate of Excellence from your <a href="/dashboard">Dashboard</a>.</p>
+      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a href="/dashboard">Dashboard</a>.</p>
 
 
       <div class="survey">

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML
 
 
       <div class="survey">
-        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <b>we’re</b> doing.</p>
+        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <em>we’re</em> doing.</p>
       </div>
     </div>
   </div>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -22,7 +22,7 @@ from openedx.core.djangolib.markup import HTML
 
 
       <div class="survey">
-        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future course offerings and let us know how <em>we’re</em> doing.</p>
+        <p>Before you head on to your next achievement, could you please take a moment to share your thoughts with us on a quick survey? Your feedback will help shape our future courses and let us know how <em>we’re</em> doing.</p>
       </div>
     </div>
   </div>

--- a/lms/templates/problem.html
+++ b/lms/templates/problem.html
@@ -18,7 +18,7 @@ from openedx.core.djangolib.markup import HTML
       <h2>Congratulations!</h2>
       <p>Congratulations on completing the course and passing the final exam with flying colors. You really know your stuff!</p>
 
-      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a href="/dashboard">Dashboard</a>.</p>
+      <p>Show off to your network by sharing your badge on LinkedIn. You can download it right from your <a class="gymlink" href="/dashboard">Dashboard</a>.</p>
 
 
       <div class="survey">


### PR DESCRIPTION
# What this PR Contains
- updated messaging that shows after courses are graded
    -  **we're** is now _we're_.
    - "course offerings" is now "courses"
    - prompt to share to LinkedIn is updated
    - Dashboard link should be orange now 💨 
- "Certificate" should be lowercase if it isn't the first word in a sentence
- Hover text for "My Certificate" on dashboard now says "View your certificate" instead of something about downloading a pdf

# What it doesn't contain
- Still not differentiating between "Certificate" and "Badge" in various copy across the site
- I still can't get the exam page to scroll up to the top to see messaging after grading is submitted.  😞 