### PR TITLE
Make the actual link text show "badge" or "certificate" as needed

### DIFF
--- a/lms/templates/dashboard/_dashboard_course_listing.html
+++ b/lms/templates/dashboard/_dashboard_course_listing.html
@@ -127,7 +127,7 @@ from student.helpers import (
               <li class="action action-certificate">
               <a href="${cert_status['download_url']}"
                 title="${_('View your ')}${credential_type}">
-                ${_("My {cert_name_short}").format(cert_name_short=cert_name_short)}</a></li>
+                ${_("My {cert_name_short}").format(cert_name_short=credential_type)}</a></li>
             </li>
           % endif
           


### PR DESCRIPTION
# What this PR does
- Makes links to accredible on student courses on the dashboard say "Badge" for gym shorts and "Certificate" for full courses