### PR TITLE
Remove badge announcement copy

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -77,7 +77,6 @@
           </ul>
 
           <h1 id="gymshorts">Gym Shorts</h1>
-          <p><strong>NEW: Gym Shorts now include badges! (Hello, bragging rights.) <a href="/faq#how-do-i-get-my-badge">Learn More</a></strong></p>
           <p class="hero">
             Gym Shorts are short courses that all last under an hour. Like our Full Courses, they are taught by industry experts and focus on current skills and technologies. Each includes approximately one hour of video instruction, a final exam, and a badge (if and) when you pass.
           </p>


### PR DESCRIPTION
# What it do
Gets rid of the line of text below this title:
![image](https://user-images.githubusercontent.com/1844496/41244808-3692b240-6d74-11e8-8735-82d745ffca00.png)
