### PR TITLE
🚨 silly bugfix alert 🚨

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       only: 
         - develop
         - /feature.*/
+        - /bug.*/
     steps: 
       - checkout
       - run: echo '[edxapp-server]' > ~/inventory

--- a/lms/templates/jobs/find_jobs.html
+++ b/lms/templates/jobs/find_jobs.html
@@ -23,7 +23,7 @@
             const longitude = position.coords.longitude;
             if (latitude && longitude) {
               const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}";
-              const microserviceUrl = baseUrl + "/" + latitude + "/" + longitude;
+              const microserviceUrl = baseUrl + "home/" + latitude + "/" + longitude;
 
               $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);
             }

--- a/lms/templates/jobs/find_jobs.html
+++ b/lms/templates/jobs/find_jobs.html
@@ -24,7 +24,6 @@
             if (latitude && longitude) {
               const baseUrl = "${settings.APPSEMBLER_FEATURES['JOBS_MODULE_BASE_URL']}";
               const microserviceUrl = baseUrl + "home/" + latitude + "/" + longitude;
-
               $('.gymnasium-jobs-microservice-iframe').attr('src', microserviceUrl);
             }
           },


### PR DESCRIPTION
This should fix the whole jobs-module-defaults-to-mike's-house thing, in concert with [this guy](https://github.com/gymnasium/jobs-microservice/pull/31).  I had the URL wrong to load jobs on the home page.  

This line needs a `/:view` URL param, so anything other than `/table` will do here:
https://github.com/gymnasium/jobs-microservice/blob/76a328069c75d44982ca750402f29d7e4d429ea7/src/App.js#L26