### PR TITLE
Hub pages meta from CMS, get rid of .xyz

### DIFF
--- a/lms/static/sass/_gymnasium.scss
+++ b/lms/static/sass/_gymnasium.scss
@@ -1300,7 +1300,11 @@ div.status,
 
   .message-copy {
     color: #fff!important;  
-  }
+	}
+
+	div.status p.message-copy {
+		color: #222222 !important;
+	}
 
   a {
     color: white !important;

--- a/lms/templates/static_templates/career-skills.html
+++ b/lms/templates/static_templates/career-skills.html
@@ -5,14 +5,7 @@
 <%block name="pagetitle">${_("Career Skills")}</%block>
 
 <%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
-  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@AquentGymnasium">
-  <meta name="twitter:url" property="og:url" content="https://thegymnasium.com/career-skills">
-  <meta name="twitter:title" property="og:title" content="Career Skills">
-  <meta name="twitter:image" property="og:image" content="https://thegymcms.com/img/social/collections/career-skills-social.png">
-  <meta name="twitter:description" property="og:description" content="Experience endless learning opportunities with our free collection of Carer Skills courses, webinars, articles, and jobs.">
+  ${gymcms.render('hub-pages/meta/career-skills-collection-meta')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/prototyping.html
+++ b/lms/templates/static_templates/prototyping.html
@@ -5,14 +5,7 @@
 <%block name="pagetitle">${_("Prototyping")}</%block>
 
 <%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
-  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@AquentGymnasium">
-  <meta name="twitter:url" property="og:url" content="https://thegymnasium.com/prototyping">
-  <meta name="twitter:title" property="og:title" content="Prototyping">
-  <meta name="twitter:image" property="og:image" content="https://thegymcms.com/img/social/collections/prototyping-social.png">
-  <meta name="twitter:description" property="og:description" content="Experience endless learning opportunities with our free collection of Prototyping courses, webinars, articles, and jobs.">
+  ${gymcms.render('/hub-pages/meta/prototyping-collection-meta')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/ux-design.html
+++ b/lms/templates/static_templates/ux-design.html
@@ -4,15 +4,9 @@
 
 <%block name="pagetitle">${_("UX Design")}</%block>
 
+
 <%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
-  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@AquentGymnasium">
-  <meta name="twitter:url" property="og:url" content="https://thegymnasium.com/ux-design">
-  <meta name="twitter:title" property="og:title" content="UX Design Collection">
-  <meta name="twitter:image" property="og:image" content="https://thegymcms.com/img/social/collections/ux-design-social.png">
-  <meta name="twitter:description" property="og:description" content="Experience endless learning opportunities with our free collection of UX courses, webinars, articles, and jobs.">
+  ${gymcms.render('/hub-pages/meta/ux-design-collection-meta')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/web-development.html
+++ b/lms/templates/static_templates/web-development.html
@@ -5,14 +5,7 @@
 <%block name="pagetitle">${_("Web Development")}</%block>
 
 <%block name="headextra">
-  ## OG (Open Graph) title and description added below to give social media info to display
-  ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:site" content="@AquentGymnasium">
-  <meta name="twitter:url" property="og:url" content="https://thegymnasium.com/web-development">
-  <meta name="twitter:title" property="og:title" content="Web Development">
-  <meta name="twitter:image" property="og:image" content="https://thegymcms.com/img/social/collections/web-development-social.png">
-  <meta name="twitter:description" property="og:description" content="Experience endless learning opportunities with our free collection of Web Development courses, webinars, articles, and jobs.">
+  ${gymcms.render('/hub-pages/meta/web-development-collection-meta/')}
 </%block>
 
 <div class="container">

--- a/lms/templates/util/gymcms.mako
+++ b/lms/templates/util/gymcms.mako
@@ -7,9 +7,9 @@
     # based on which environment we're in
     if templateUrl:
       if settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', 'staging') == "staging":
-        fullUrl = 'https://staging.gymcms.xyz/static/' + templateUrl
+        fullUrl = 'https://staging.thegymcms.com/static/' + templateUrl
       elif settings.APPSEMBLER_FEATURES.get('ENVIRONMENT', '') == "production":
-        fullUrl = 'https://gymcms.xyz/static/' + templateUrl
+        fullUrl = 'https://thegymcms.com/static/' + templateUrl
 
       # provided the last step worked, use a try block to pull that data from the web
       # render a hidden div if it fails, so it doesn't crash the rest of the page.


### PR DESCRIPTION
This resolves:
- https://github.com/gymnasium/tracker/issues/11
- https://github.com/gymnasium/tracker/issues/13
- https://github.com/gymnasium/tracker/issues/15
- https://github.com/gymnasium/tracker/issues/16
- https://github.com/gymnasium/tracker/issues/17
- https://github.com/gymnasium/tracker/issues/18