### PR TITLE
Configure individual webinar pages

### DIFF
--- a/lms/templates/static_templates/webinars.html
+++ b/lms/templates/static_templates/webinars.html
@@ -4,6 +4,10 @@
 
 <%block name="pagetitle">${_("Webinars")}</%block>
 
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
 <div class="container ">
 	<div class="row">
 		<div class="col-md-12 ">

--- a/lms/templates/static_templates/webinars/design-systems-and-creativity.html
+++ b/lms/templates/static_templates/webinars/design-systems-and-creativity.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Design Systems and Creativity: Unlikely Allies")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/design-systems-and-creativity')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/design-systems-and-creativity.html
+++ b/lms/templates/static_templates/webinars/design-systems-and-creativity.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Design Systems and Creativity: Unlikely Allies")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/design-systems-and-creativity')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/designing-for-real-people.html
+++ b/lms/templates/static_templates/webinars/designing-for-real-people.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Designing for Real People: Making the Case for Meaningful UX")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/designing-for-real-people')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/designing-for-real-people.html
+++ b/lms/templates/static_templates/webinars/designing-for-real-people.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Designing for Real People: Making the Case for Meaningful UX")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/designing-for-real-people')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/designing-for-understanding.html
+++ b/lms/templates/static_templates/webinars/designing-for-understanding.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Designing for Understanding: Create Meaningful Interactions for Web and Mobile")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/designing-for-understanding')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/designing-for-understanding.html
+++ b/lms/templates/static_templates/webinars/designing-for-understanding.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Designing for Understanding: Create Meaningful Interactions for Web and Mobile")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/designing-for-understanding')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/future-of-web-layout.html
+++ b/lms/templates/static_templates/webinars/future-of-web-layout.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("The Future of Web Layout")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/future-of-web-layout')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/future-of-web-layout.html
+++ b/lms/templates/static_templates/webinars/future-of-web-layout.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("The Future of Web Layout")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/future-of-web-layout')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/keeping-up-with-javascript.html
+++ b/lms/templates/static_templates/webinars/keeping-up-with-javascript.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Keeping Up with JavaScript is a Full-time Job")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/keeping-up-with-javascript')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/keeping-up-with-javascript.html
+++ b/lms/templates/static_templates/webinars/keeping-up-with-javascript.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Keeping Up with JavaScript is a Full-time Job")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/keeping-up-with-javascript')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/planning-before-pixels.html
+++ b/lms/templates/static_templates/webinars/planning-before-pixels.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Planning Before Pixels: Create with Purpose")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/planning-before-pixels')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/planning-before-pixels.html
+++ b/lms/templates/static_templates/webinars/planning-before-pixels.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Planning Before Pixels: Create with Purpose")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/planning-before-pixels')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/prototyping-as-process.html
+++ b/lms/templates/static_templates/webinars/prototyping-as-process.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("UX Design: Prototyping as Process")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/prototyping-as-process')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/prototyping-as-process.html
+++ b/lms/templates/static_templates/webinars/prototyping-as-process.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("UX Design: Prototyping as Process")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/prototyping-as-process')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/remote-work.html
+++ b/lms/templates/static_templates/webinars/remote-work.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Remote Work: Can it Work for You?")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/remote-work')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/remote-work.html
+++ b/lms/templates/static_templates/webinars/remote-work.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Remote Work: Can it Work for You?")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/remote-work')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/rethinking-full-stack.html
+++ b/lms/templates/static_templates/webinars/rethinking-full-stack.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("Rethinking Full Stack: Cost and Compromise")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/rethinking-full-stack')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/rethinking-full-stack.html
+++ b/lms/templates/static_templates/webinars/rethinking-full-stack.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Rethinking Full Stack: Cost and Compromise")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/rethinking-full-stack')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/right-sizing-your-rapid-prototypes.html
+++ b/lms/templates/static_templates/webinars/right-sizing-your-rapid-prototypes.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Right-Sizing Your Rapid Prototypes for Web and Mobile")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/right-sizing-your-rapid-prototypes')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/right-sizing-your-rapid-prototypes.html
+++ b/lms/templates/static_templates/webinars/right-sizing-your-rapid-prototypes.html
@@ -2,7 +2,7 @@
 <%inherit file="../../main.html" />
 <%namespace name="gymcms" file="../../util/gymcms.mako" />
 
-<%block name="pagetitle">${_("Web Design is Hard")}</%block>
+<%block name="pagetitle">${_("Right-Sizing Your Rapid Prototypes for Web and Mobile")}</%block>
 
 <%block name="headextra">
   ${gymcms.render('/hub-pages/meta/webinars/')}
@@ -11,7 +11,7 @@
 <div class="container">
 	<div class="row">
 		<div class="col-md-12">
-      ${gymcms.render('webinars/web-design-is-hard')}
+      ${gymcms.render('webinars/right-sizing-your-rapid-prototypes')}
 		</div>
 	</div>
 </div>

--- a/lms/templates/static_templates/webinars/state-of-responsive-web-design.html
+++ b/lms/templates/static_templates/webinars/state-of-responsive-web-design.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("The State of Responsive Design")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/state-of-responsive-design')}
 </%block>
 
 <div class="container">

--- a/lms/templates/static_templates/webinars/state-of-responsive-web-design.html
+++ b/lms/templates/static_templates/webinars/state-of-responsive-web-design.html
@@ -1,0 +1,17 @@
+<%! from django.utils.translation import ugettext as _ %>
+<%inherit file="../main.html" />
+<%namespace name="gymcms" file="../util/gymcms.mako" />
+
+<%block name="pagetitle">${_("The State of Responsive Design")}</%block>
+
+<%block name="headextra">
+  ${gymcms.render('/hub-pages/meta/webinars/')}
+</%block>
+
+<div class="container">
+	<div class="row">
+    <div class="col-md-12">
+      ${gymcms.render('webinars/state-of-responsive-design')}
+    </div>
+  </div>
+</div>

--- a/lms/templates/static_templates/webinars/web-design-is-hard.html
+++ b/lms/templates/static_templates/webinars/web-design-is-hard.html
@@ -5,7 +5,7 @@
 <%block name="pagetitle">${_("Web Design is Hard")}</%block>
 
 <%block name="headextra">
-  ${gymcms.render('/hub-pages/meta/webinars/')}
+  ${gymcms.render('webinars/meta/web-design-is-hard')}
 </%block>
 
 <div class="container">


### PR DESCRIPTION
Fixes https://github.com/gymnasium/tracker/issues/28 - with some questions (see issue).

New configuration entries required in `mktg_urls`: 

```es6
{
  // ...
  "webinars/design-systems-and-creativity": "webinars/design-systems-and-creativity",
  "webinars/designing-for-real-people": "webinars/designing-for-real-people",
  "webinars/designing-for-understanding": "webinars/designing-for-understanding",
  "webinars/future-of-web-layout": "webinars/future-of-web-layout",
  "webinars/keeping-up-with-javascript": "webinars/keeping-up-with-javascript",
  "webinars/planning-before-pixels": "webinars/planning-before-pixels",
  "webinars/prototyping-as-process": "webinars/prototyping-as-process",
  "webinars/remote-work": "webinars/remote-work",
  "webinars/rethinking-full-stack": "webinars/rethinking-full-stack",
  "webinars/right-sizing-your-rapid-prototypes": "webinars/right-sizing-your-rapid-prototypes",
  "webinars/state-of-responsive-web-design": "webinars/state-of-responsive-web-design",
  "webinars/web-design-is-hard": "webinars/web-design-is-hard"
}
```